### PR TITLE
Issue #2395397 by fastangel, thechanceg, Dave Reid: Fixed doctype not…

### DIFF
--- a/xsl/xmlsitemap.xsl
+++ b/xsl/xmlsitemap.xsl
@@ -27,7 +27,7 @@
     xmlns:html="http://www.w3.org/TR/REC-html40"
     xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-  <xsl:output method="html" version="1.0" encoding="utf-8" indent="yes"/>
+  <xsl:output method="html" doctype-system="about:legacy-compat" encoding="UTF-8" indent="yes" />
   <!-- Root template -->
   <xsl:template match="/">
     <html>


### PR DESCRIPTION
… set properly in sitemap.xsl.

This commit is in the official version on D.O, but is missing from D6LTS version.
https://git.drupalcode.org/project/xmlsitemap/commit/0d8590300c881748a80701ddda959b6d544e642c